### PR TITLE
Fix JDK 8 build support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 		<jaxb.version>${jaxb22.version}</jaxb.version>
 		<jaxb2-basics.version>0.9.0</jaxb2-basics.version>
 		<maven.plugin.testing.version>2.1</maven.plugin.testing.version>
-		<maven.plugin.plugin.version>3.2</maven.plugin.plugin.version>
+		<maven.plugin.plugin.version>3.4</maven.plugin.plugin.version>
 		<slf4j.version>1.7.7</slf4j.version>
 	</properties>
 	<profiles>


### PR DESCRIPTION
When trying to build the plugin with Java 8, I got an error similar to the one on [this Chinese site](http://www.blogjava.net/andyj2ee/archive/2014/12/17/421502.html), except with an `ArrayIndexOutOfBoundsException` at index 8449 rather than 48188. Upgrading the `maven-plugin-plugin` resolves the issue. (I went with version [3.4](http://jira.codehaus.org/browse/MPLUGIN/fixforversion/20381), but [3.3](http://jira.codehaus.org/browse/MPLUGIN/fixforversion/18959) would work as well. Did not pinpoint which exact ticket fixed the issue on their side.)