### PR TITLE
Proxy configuration in maven (settings) used with xjc execution

### DIFF
--- a/plugin-2.0/src/main/java/org/jvnet/mjiip/v_2_0/OptionsFactory.java
+++ b/plugin-2.0/src/main/java/org/jvnet/mjiip/v_2_0/OptionsFactory.java
@@ -16,7 +16,7 @@ public class OptionsFactory implements
 		org.jvnet.jaxb2.maven2.OptionsFactory<Options> {
 	/**
 	 * Creates and initializes an instance of XJC options.
-	 * 
+	 *
 	 */
 	public Options createOptions(OptionsConfiguration optionsConfiguration)
 			throws MojoExecutionException {
@@ -67,6 +67,16 @@ public class OptionsFactory implements
 
 		if (optionsConfiguration.isExtension()) {
 			options.compatibilityMode = Options.EXTENSION;
+		}
+
+		String proxy = optionsConfiguration.getProxy();
+		if ((proxy != null) && (proxy.length() > 0)) {
+			try {
+				options.parseArguments(new String[] { "-httpproxy", proxy });
+			}
+			catch (BadCommandLineException bclex) {
+				throw new MojoExecutionException("Error parsing the proxy line ", bclex);
+			}
 		}
 
 		final List<String> arguments = optionsConfiguration.getArguments();

--- a/plugin-2.1/src/main/java/org/jvnet/mjiip/v_2_1/OptionsFactory.java
+++ b/plugin-2.1/src/main/java/org/jvnet/mjiip/v_2_1/OptionsFactory.java
@@ -17,7 +17,7 @@ public class OptionsFactory implements
 		org.jvnet.jaxb2.maven2.OptionsFactory<Options> {
 	/**
 	 * Creates and initializes an instance of XJC options.
-	 * 
+	 *
 	 */
 	public Options createOptions(OptionsConfiguration optionsConfiguration)
 			throws MojoExecutionException {
@@ -70,6 +70,16 @@ public class OptionsFactory implements
 
 		if (optionsConfiguration.isExtension()) {
 			options.compatibilityMode = Options.EXTENSION;
+		}
+
+		String proxy = optionsConfiguration.getProxy();
+		if ((proxy != null) && (proxy.length() > 0)) {
+			try {
+				options.parseArguments(new String[] { "-httpproxy", proxy });
+			}
+			catch (BadCommandLineException bclex) {
+				throw new MojoExecutionException("Error parsing the proxy line ", bclex);
+			}
 		}
 
 		final List<String> arguments = optionsConfiguration.getArguments();

--- a/plugin-2.2/src/main/java/org/jvnet/mjiip/v_2_2/OptionsFactory.java
+++ b/plugin-2.2/src/main/java/org/jvnet/mjiip/v_2_2/OptionsFactory.java
@@ -19,7 +19,7 @@ public class OptionsFactory implements
 		org.jvnet.jaxb2.maven2.OptionsFactory<Options> {
 	/**
 	 * Creates and initializes an instance of XJC options.
-	 * 
+	 *
 	 */
 	public Options createOptions(OptionsConfiguration optionsConfiguration)
 			throws MojoExecutionException {
@@ -78,6 +78,16 @@ public class OptionsFactory implements
 
 		if (optionsConfiguration.isExtension()) {
 			options.compatibilityMode = Options.EXTENSION;
+		}
+
+		String proxy = optionsConfiguration.getProxy();
+		if ((proxy != null) && (proxy.length() > 0)) {
+			try {
+				options.parseArguments(new String[] { "-httpproxy", proxy });
+			}
+			catch (BadCommandLineException bclex) {
+				throw new MojoExecutionException("Error parsing the proxy line ", bclex);
+			}
 		}
 
 		final List<String> arguments = optionsConfiguration.getArguments();

--- a/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/OptionsConfiguration.java
+++ b/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/OptionsConfiguration.java
@@ -33,6 +33,8 @@ public class OptionsConfiguration {
 	private final String accessExternalDTD;
 	private final boolean contentForWildcard;
 
+	private final String proxy;
+
 	private final boolean extension;
 
 	private final boolean strict;
@@ -58,7 +60,7 @@ public class OptionsConfiguration {
 
 			boolean extension, boolean strict, boolean verbose,
 			boolean debugMode, List<String> arguments, List<URL> plugins,
-			String specVersion) {
+			String specVersion, String proxy) {
 		super();
 		this.encoding = encoding;
 		this.schemaLanguage = schemaLanguage;
@@ -82,6 +84,7 @@ public class OptionsConfiguration {
 		this.arguments = arguments;
 		this.plugins = plugins;
 		this.specVersion = specVersion;
+		this.proxy = proxy;
 	}
 
 	public String getEncoding() {
@@ -166,6 +169,10 @@ public class OptionsConfiguration {
 
 	public String getSpecVersion() {
 		return specVersion;
+	}
+
+	public String getProxy() {
+		return proxy;
 	}
 
 	public List<URL> getPlugins() {

--- a/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/RawXJC2Mojo.java
+++ b/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/RawXJC2Mojo.java
@@ -1030,7 +1030,7 @@ public abstract class RawXJC2Mojo<O> extends AbstractXJC2Mojo<O> {
 				getAccessExternalSchema(), getAccessExternalDTD(),
 				getContentForWildcard(), getExtension(), getStrict(),
 				getVerbose(), getDebug(), getArguments(), getXjcPluginURLs(),
-				getSpecVersion());
+				getSpecVersion(), getProxy());
 		return optionsConfiguration;
 	}
 

--- a/plugin/src/main/java/org/jvnet/mjiip/v_2/OptionsFactory.java
+++ b/plugin/src/main/java/org/jvnet/mjiip/v_2/OptionsFactory.java
@@ -82,6 +82,16 @@ public class OptionsFactory implements
 			options.compatibilityMode = Options.EXTENSION;
 		}
 
+		String proxy = optionsConfiguration.getProxy();
+		if ((proxy != null) && (proxy.length() > 0)) {
+			try {
+				options.parseArguments(new String[] { "-httpproxy", proxy });
+			}
+			catch (BadCommandLineException bclex) {
+				throw new MojoExecutionException("Error parsing the proxy line ", bclex);
+			}
+		}
+
 		final List<String> arguments = optionsConfiguration.getArguments();
 		try {
 			options.parseArguments(arguments.toArray(new String[arguments


### PR DESCRIPTION
Useful for recovering XSD dependencies (in XSD parsing) behind a proxy.

Code extracted from justinsb/jaxb2-maven-plugin (jaxb2 plugin previously in codehaus).