### PR TITLE
jaxb:typesafeEnumClass doesn't play nice with episode based projects

### DIFF
--- a/samples/episode/a/src/main/java/a/Factory.java
+++ b/samples/episode/a/src/main/java/a/Factory.java
@@ -1,0 +1,17 @@
+package a;
+
+public class Factory {
+
+    public void checkEnumValues(){
+        // doesn't matter what we put here, we just want to make sure the enums are being constructed correctly
+        if(A2EnumType.ABC == A2EnumType.DEF){
+            System.exit(1);
+        }
+        if(A3EnumType.START == A3EnumType.FINISH){
+            System.exit(1);
+        }
+        if(A4EnumType.START == A4EnumType.FINISH){
+            System.exit(1);
+        }
+    }
+}

--- a/samples/episode/a/src/main/resources/a.xsd
+++ b/samples/episode/a/src/main/resources/a.xsd
@@ -21,11 +21,12 @@
 	</xsd:complexType>
 
 	<xsd:simpleType name="A2EnumType">
-		<xsd:annotation>
-			<xsd:appinfo>
-				<jaxb:typesafeEnumClass/>
-			</xsd:appinfo>
-		</xsd:annotation>
+		<!-- This shouldn't really be necessary should it? -->
+		<!--<xsd:annotation>-->
+			<!--<xsd:appinfo>-->
+				<!--<jaxb:typesafeEnumClass/>-->
+			<!--</xsd:appinfo>-->
+		<!--</xsd:annotation>-->
 		<xsd:restriction base="xsd:string">
 			<xsd:enumeration value="ABC" />
 			<xsd:enumeration value="DEF" />
@@ -33,5 +34,54 @@
 		</xsd:restriction>
 	</xsd:simpleType>
 
+	<xsd:simpleType name="A3EnumType">
+		<!-- if base type is an xsd:string then including this annotation would fail the import -->
+		<!--<xsd:annotation>-->
+			<!--<xsd:appinfo>-->
+				<!--<jaxb:typesafeEnumClass/>-->
+			<!--</xsd:appinfo>-->
+		<!--</xsd:annotation>-->
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="0" >
+				<xsd:annotation>
+					<xsd:appinfo>
+						<jaxb:typesafeEnumMember name="START"/>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="1">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<jaxb:typesafeEnumMember name="FINISH"/>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="A4EnumType">
+		<!-- if base type is an xsd:int we don't actually bind the clas correctly unless we include the typesafeEnumClass -->
+		<xsd:annotation>
+			<xsd:appinfo>
+				<jaxb:typesafeEnumClass/>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:int">
+			<xsd:enumeration value="0" >
+				<xsd:annotation>
+					<xsd:appinfo>
+						<jaxb:typesafeEnumMember name="START"/>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="1">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<jaxb:typesafeEnumMember name="FINISH"/>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
 
 </xsd:schema>


### PR DESCRIPTION
I have been struggling to get episode based compilation to work on an existing codebase. Using these samples I have been able to get most of the way then ran into this show stopper with enum values. I was able to replicate this in your sample projects. Basically it looks like there is some sort of issue with including the typesafeEnumClass in some cases. In particular I ran into this issue with an integer enum class but it appears to be occur if you use both typesafeEnumClass and typesafeEnumMember on a string enum.

I think the "default bindings" may somehow related but I am out of my depth on how I would go about fixing this. If there is a simple solution it wouldn't be a bad idea to add to sample project.

Thanks for your hard work on this plugin, having samples and tests made it infinitely easier for me to boil down by use case to this minimal reproduction case. Happy New Year!

Errors are:
```
[ERROR] Error while parsing schema(s).Location [ https://maven-jaxb2-plugin.dev.java.net/svn/maven-jaxb2-plugin/trunk/samples/episode/a/src/main/resources/a.xsd{66,30}].
com.sun.istack.SAXParseException2; systemId: https://maven-jaxb2-plugin.dev.java.net/svn/maven-jaxb2-plugin/trunk/samples/episode/a/src/main/resources/a.xsd; lineNumber: 66; columnNumber: 30; compiler was unable to honor this enum customization. It is attached to a wrong place, or its inconsistent with other bindings.
	at com.sun.tools.xjc.ErrorReceiver.error(ErrorReceiver.java:86)
	at com.sun.tools.xjc.reader.xmlschema.ErrorReporter.error(ErrorReporter.java:84)
	at com.sun.tools.xjc.reader.xmlschema.UnusedCustomizationChecker.check(UnusedCustomizationChecker.java:149)
	at com.sun.tools.xjc.reader.xmlschema.UnusedCustomizationChecker.check(UnusedCustomizationChecker.java:127)
	at com.sun.tools.xjc.reader.xmlschema.UnusedCustomizationChecker.simpleType(UnusedCustomizationChecker.java:240)
	at com.sun.xml.xsom.impl.SimpleTypeImpl.visit(SimpleTypeImpl.java:164)
	at com.sun.tools.xjc.reader.xmlschema.UnusedCustomizationChecker.run(UnusedCustomizationChecker.java:113)
	at com.sun.tools.xjc.reader.xmlschema.UnusedCustomizationChecker.run(UnusedCustomizationChecker.java:107)
	at com.sun.tools.xjc.reader.xmlschema.BGMBuilder._build(BGMBuilder.java:181)
	at com.sun.tools.xjc.reader.xmlschema.BGMBuilder.build(BGMBuilder.java:119)
	at com.sun.tools.xjc.ModelLoader.annotateXMLSchema(ModelLoader.java:425)
	at com.sun.tools.xjc.ModelLoader.load(ModelLoader.java:174)
	at com.sun.tools.xjc.ModelLoader.load(ModelLoader.java:119)
	at org.jvnet.mjiip.v_2_2.XJC22Mojo.loadModel(XJC22Mojo.java:50)
	at org.jvnet.mjiip.v_2_2.XJC22Mojo.doExecute(XJC22Mojo.java:40)
	at org.jvnet.mjiip.v_2_2.XJC22Mojo.doExecute(XJC22Mojo.java:28)
	at org.jvnet.jaxb2.maven2.RawXJC2Mojo.doExecute(RawXJC2Mojo.java:505)
	at org.jvnet.jaxb2.maven2.RawXJC2Mojo.execute(RawXJC2Mojo.java:328)
	at ...
[ERROR] Error while parsing schema(s).Location [ https://maven-jaxb2-plugin.dev.java.net/svn/maven-jaxb2-plugin/trunk/samples/episode/a/src/main/resources/a.xsd{62,36}].
com.sun.istack.SAXParseException2; systemId: https://maven-jaxb2-plugin.dev.java.net/svn/maven-jaxb2-plugin/trunk/samples/episode/a/src/main/resources/a.xsd; lineNumber: 62; columnNumber: 36; (the above customization is attached to the following location in the schema)
	at com.sun.tools.xjc.ErrorReceiver.error(ErrorReceiver.java:86)
	at com.sun.tools.xjc.reader.xmlschema.ErrorReporter.error(ErrorReporter.java:84)
	at com.sun.tools.xjc.reader.xmlschema.UnusedCustomizationChecker.check(UnusedCustomizationChecker.java:154)
	at com.sun.tools.xjc.reader.xmlschema.UnusedCustomizationChecker.check(UnusedCustomizationChecker.java:127)
	at com.sun.tools.xjc.reader.xmlschema.UnusedCustomizationChecker.simpleType(UnusedCustomizationChecker.java:240)
	at com.sun.xml.xsom.impl.SimpleTypeImpl.visit(SimpleTypeImpl.java:164)
	at com.sun.tools.xjc.reader.xmlschema.UnusedCustomizationChecker.run(UnusedCustomizationChecker.java:113)
	at com.sun.tools.xjc.reader.xmlschema.UnusedCustomizationChecker.run(UnusedCustomizationChecker.java:107)
	at com.sun.tools.xjc.reader.xmlschema.BGMBuilder._build(BGMBuilder.java:181)
	at com.sun.tools.xjc.reader.xmlschema.BGMBuilder.build(BGMBuilder.java:119)
	at com.sun.tools.xjc.ModelLoader.annotateXMLSchema(ModelLoader.java:425)
	at com.sun.tools.xjc.ModelLoader.load(ModelLoader.java:174)
	at com.sun.tools.xjc.ModelLoader.load(ModelLoader.java:119)
	at org.jvnet.mjiip.v_2_2.XJC22Mojo.loadModel(XJC22Mojo.java:50)
	at org.jvnet.mjiip.v_2_2.XJC22Mojo.doExecute(XJC22Mojo.java:40)
	at org.jvnet.mjiip.v_2_2.XJC22Mojo.doExecute(XJC22Mojo.java:28)
	at org.jvnet.jaxb2.maven2.RawXJC2Mojo.doExecute(RawXJC2Mojo.java:505)
	at org.jvnet.jaxb2.maven2.RawXJC2Mojo.execute(RawXJC2Mojo.java:328)
	at ...
```