### PR TITLE
allow custom proxy configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+/.idea
+*.iml
 /err
 /std

--- a/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/AbstractXJC2Mojo.java
+++ b/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/AbstractXJC2Mojo.java
@@ -70,6 +70,60 @@ public abstract class AbstractXJC2Mojo<O> extends AbstractMojo implements
 		this.useActiveProxyAsHttpproxy = useActiveProxyAsHttpproxy;
 	}
 
+	private boolean useCustomProxyConfiguration = false;
+
+	public boolean isUseCustomProxyConfiguration() {
+		return useCustomProxyConfiguration;
+	}
+
+	@Parameter(property = "maven.xjc2.proxyHost")
+	private String proxyHost;
+
+	public void setProxyHost(String proxyHost) {
+		useCustomProxyConfiguration = true;
+		this.proxyHost = proxyHost;
+	}
+
+	public String getProxyHost() {
+		return this.proxyHost;
+	}
+
+	@Parameter(property = "maven.xjc2.proxyPort")
+	private int proxyPort;
+
+	public void setProxyPort(int proxyPort) {
+		useCustomProxyConfiguration = true;
+		this.proxyPort = proxyPort;
+	}
+
+	public int getProxyPort() {
+		return this.proxyPort;
+	}
+
+	@Parameter(property = "maven.xjc2.proxyUsername")
+	private String proxyUsername;
+
+	public void setProxyUsername(String proxyUsername) {
+		useCustomProxyConfiguration = true;
+		this.proxyUsername = proxyUsername;
+	}
+
+	public String getProxyUsername() {
+		return this.proxyUsername;
+	}
+
+	@Parameter(property = "maven.xjc2.proxyPassword")
+	private String proxyPassword;
+
+	public void setProxyPassword(String proxyPassword) {
+		useCustomProxyConfiguration = true;
+		this.proxyPassword = proxyPassword;
+	}
+
+	public String getProxyPassword() {
+		return this.proxyPassword;
+	}
+
 	/**
 	 * Encoding for the generated sources, defaults to
 	 * ${project.build.sourceEncoding}.

--- a/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/RawXJC2Mojo.java
+++ b/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/RawXJC2Mojo.java
@@ -1051,6 +1051,9 @@ public abstract class RawXJC2Mojo<O> extends AbstractXJC2Mojo<O> {
 		final boolean upToDate = dependsTimestamp < producesTimestamp;
 		return upToDate;
 	}
+	protected String getCustomHttpproxy() {
+		return createXJCProxyArgument(getProxyHost(), getProxyPort(), getProxyUsername(), getProxyPassword());
+	}
 
 	protected String getActiveProxyAsHttpproxy() {
 		if (getSettings() == null) {
@@ -1064,15 +1067,17 @@ public abstract class RawXJC2Mojo<O> extends AbstractXJC2Mojo<O> {
 			return null;
 		}
 
+		return createXJCProxyArgument(activeProxy.getHost(), activeProxy.getPort(), activeProxy.getUsername(), activeProxy.getPassword());
+	}
+
+	private String createXJCProxyArgument(String host, int port, String username, String password) {
 		// The XJC proxy argument should be on the form
 		// [user[:password]@]proxyHost[:proxyPort]
 		final StringBuilder proxyStringBuilder = new StringBuilder();
-		final String username = activeProxy.getUsername();
 		if (username != null) {
 			// Start with the username.
 			proxyStringBuilder.append(username);
 			// Append the password if provided.
-			final String password = activeProxy.getPassword();
 			if (password != null) {
 				proxyStringBuilder.append(":").append(password);
 			}
@@ -1080,12 +1085,10 @@ public abstract class RawXJC2Mojo<O> extends AbstractXJC2Mojo<O> {
 		}
 
 		// Append hostname and port.
-		final String host = activeProxy.getHost();
 		proxyStringBuilder.append(host);
 
-		final int port = activeProxy.getPort();
 		if (port != -1) {
-			proxyStringBuilder.append(":").append(activeProxy.getPort());
+			proxyStringBuilder.append(":").append(port);
 		}
 		return proxyStringBuilder.toString();
 	}
@@ -1105,6 +1108,12 @@ public abstract class RawXJC2Mojo<O> extends AbstractXJC2Mojo<O> {
 		String httpproxy = null;
 		if (isUseActiveProxyAsHttpproxy()) {
 			httpproxy = getActiveProxyAsHttpproxy();
+		}
+		if (isUseCustomProxyConfiguration()) {
+			httpproxy = getCustomHttpproxy();
+			if (isUseActiveProxyAsHttpproxy()) {
+				getLog().warn("active proxy settings will be overwritten by custom proxy configuration");
+			}
 		}
 		if (httpproxy != null) {
 			arguments.add("-httpproxy");


### PR DESCRIPTION
This pr adds the following configuration parameters for custom proxy configuration:

* `proxyHost`
* `proxyPort`
* `proxyUsername`
* `proxyPassword`

This solution was selected, because we do want to configure a global HTTP proxy per build.
