### PR TITLE
Test case for #82 toolchain awareness

### DIFF
--- a/tests/gh-issue-82/pom.xml
+++ b/tests/gh-issue-82/pom.xml
@@ -1,0 +1,66 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.jvnet.jaxb2.maven2</groupId>
+	<artifactId>maven-jaxb2-plugin-tests-gh-issue-82</artifactId>
+	<parent>
+		<groupId>org.jvnet.jaxb2.maven2</groupId>
+		<artifactId>maven-jaxb2-plugin-tests</artifactId>
+		<version>0.13.2-SNAPSHOT</version>
+	</parent>
+	<packaging>jar</packaging>
+	<name>Maven JAXB 2.x Plugin Tests [GitHub Issue #82]</name>
+	<dependencies>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-impl</artifactId>
+			<version>${jaxb.version}</version>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.jvnet.jaxb2.maven2</groupId>
+				<artifactId>maven-jaxb2-plugin</artifactId>
+				<!--
+				Compiling using a javac 1.8 with source and target set to 1.6 needs this to work properly.
+				The toolchain plugin is used to set the proper jdk 6 home for cross compilation.
+				The jaxb2 plugin uses the 2.2 spec which is the default for java 1.8 instead of the 2.1 version.
+				 -->
+				<!--
+				<configuration>
+					<specVersion>2.1</specVersion>
+				</configuration>
+				-->
+			</plugin>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-toolchains-plugin</artifactId>
+				<version>1.1</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>toolchain</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<toolchains>
+						<jdk>
+							<version>1.6</version>
+							<vendor>oracle</vendor>
+						</jdk>
+					</toolchains>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tests/gh-issue-82/src/main/resources/test.xsd
+++ b/tests/gh-issue-82/src/main/resources/test.xsd
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="Parent">
+        <xs:complexType>
+            <xs:choice maxOccurs="unbounded">
+                <xs:element ref="Child1"/>
+                <xs:element ref="Child2"/>
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="Child1" type="TestType"/>
+    <xs:element name="Child2" type="TestType"/>
+
+    <xs:simpleType name="TestType">
+        <xs:restriction base="xs:string">
+            <xs:length value="5"/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>

--- a/tests/gh-issue-82/toolchains.xml
+++ b/tests/gh-issue-82/toolchains.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<toolchains>
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>1.6</version>
+            <vendor>oracle</vendor>
+        </provides>
+        <configuration>
+            <jdkHome>/usr/lib/jvm/jdk-6-oracle-x64</jdkHome>
+        </configuration>
+    </toolchain>
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>1.8</version>
+            <vendor>oracle</vendor>
+        </provides>
+        <configuration>
+            <jdkHome>/usr/lib/jvm/jdk-8-oracle-x64</jdkHome>
+        </configuration>
+    </toolchain>
+</toolchains>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -41,6 +41,7 @@
 		<module>gh-issue-22</module>
 		<module>gh-issue-23</module>
 		<module>gh-issue-58</module>
+		<module>gh-issue-82</module>
 	</modules>
 	<build>
 		<pluginManagement>


### PR DESCRIPTION
I created a test case but to make the build fail you need to be using java 7 or 8 as default and have jdk 1.6 installed for cross compilation.
Then put the provided toolchains.xml in ~/.m2/toolchains.xml adjusting the path for your jdk home accordingly.

When compiling the generated the sources with this configuration you should see the error I mentioned in the issue.