### PR TITLE
Implement schema downloader for http basic authentication

### DIFF
--- a/plugin-core/pom.xml
+++ b/plugin-core/pom.xml
@@ -18,6 +18,11 @@
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.5</version>
+		</dependency>
+		<dependency>
 			<groupId>com.sun.org.apache.xml.internal</groupId>
 			<artifactId>resolver</artifactId>
 			<version>20050927</version>

--- a/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/AbstractXJC2Mojo.java
+++ b/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/AbstractXJC2Mojo.java
@@ -172,7 +172,9 @@ public abstract class AbstractXJC2Mojo<O> extends AbstractMojo implements
 	}
 
 	public boolean hasBasicAuthentication() {
-		return StringUtils.isNotEmpty(basicAuthentication.getUsername()) && basicAuthentication.getUrls().length > 0;
+		return null != basicAuthentication
+				&& StringUtils.isNotEmpty(basicAuthentication.getUsername())
+				&& basicAuthentication.getUrls().length > 0;
 	}
 
 	/**

--- a/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/AbstractXJC2Mojo.java
+++ b/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/AbstractXJC2Mojo.java
@@ -15,6 +15,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
@@ -157,6 +158,21 @@ public abstract class AbstractXJC2Mojo<O> extends AbstractMojo implements
 
 	public void setSchemaLanguage(String schemaLanguage) {
 		this.schemaLanguage = schemaLanguage;
+	}
+
+	@Parameter
+	private BasicAuthentication basicAuthentication;
+
+	public BasicAuthentication getBasicAuthentication() {
+		return basicAuthentication;
+	}
+
+	public void setBasicAuthentication(BasicAuthentication basicAuthentication) {
+		this.basicAuthentication = basicAuthentication;
+	}
+
+	public boolean hasBasicAuthentication() {
+		return StringUtils.isNotEmpty(basicAuthentication.getUsername()) && basicAuthentication.getUrls().length > 0;
 	}
 
 	/**

--- a/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/BasicAuthentication.java
+++ b/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/BasicAuthentication.java
@@ -1,0 +1,53 @@
+
+package org.jvnet.jaxb2.maven2;
+
+/**
+ * Created by Lucas Le on 11/9/16.
+ */
+public class BasicAuthentication {
+    private String username;
+    private String password;
+    private String downloadDirectory;
+    private String wsdlPrefixName;
+    private String[] urls = new String[0];
+
+    public String[] getUrls() {
+        return urls;
+    }
+
+    public void setUrls(String[] urls) {
+        this.urls = urls;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getDownloadDirectory() {
+        return downloadDirectory;
+    }
+
+    public void setDownloadDirectory(String downloadDirectory) {
+        this.downloadDirectory = downloadDirectory;
+    }
+
+    public String getWsdlPrefixName() {
+        return wsdlPrefixName;
+    }
+
+    public void setWsdlPrefixName(String wsdlPrefixName) {
+        this.wsdlPrefixName = wsdlPrefixName;
+    }
+}

--- a/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/RawXJC2Mojo.java
+++ b/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/RawXJC2Mojo.java
@@ -14,6 +14,14 @@
 
 package org.jvnet.jaxb2.maven2;
 
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMResult;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -34,15 +42,6 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMResult;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-import javax.xml.transform.stream.StreamSource;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
@@ -421,6 +420,12 @@ public abstract class RawXJC2Mojo<O> extends AbstractXJC2Mojo<O> {
 		setupLogging();
 		if (getVerbose())
 			getLog().info("Started execution.");
+
+		if (hasBasicAuthentication()){
+			getBasicAuthentication().setDownloadDirectory(processDownloadDirectory());
+			WsdlDownloader wsdlDownloader = new WsdlDownloader(getBasicAuthentication());
+			wsdlDownloader.execute();
+		}
 		setupMavenPaths();
 		setupCatalogResolver();
 		setupEntityResolver();
@@ -479,6 +484,10 @@ public abstract class RawXJC2Mojo<O> extends AbstractXJC2Mojo<O> {
 		if (getVerbose()) {
 			getLog().info("Finished execution.");
 		}
+	}
+
+	private String processDownloadDirectory() {
+		return getSchemaDirectory() == null ? getBasicAuthentication().getDownloadDirectory() : getSchemaDirectory().getAbsolutePath();
 	}
 
 	private void addIfExistsToEpisodeSchemaBindings() throws MojoExecutionException {

--- a/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/RawXJC2Mojo.java
+++ b/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/RawXJC2Mojo.java
@@ -423,8 +423,8 @@ public abstract class RawXJC2Mojo<O> extends AbstractXJC2Mojo<O> {
 
 		if (hasBasicAuthentication()){
 			getBasicAuthentication().setDownloadDirectory(processDownloadDirectory());
-			WsdlDownloader wsdlDownloader = new WsdlDownloader(getBasicAuthentication());
-			wsdlDownloader.execute();
+			SchemaDownloader schemaDownloader = new SchemaDownloader(getBasicAuthentication());
+			schemaDownloader.execute();
 		}
 		setupMavenPaths();
 		setupCatalogResolver();

--- a/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/SchemaDownloader.java
+++ b/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/SchemaDownloader.java
@@ -17,7 +17,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 /**
  * Created by Lucas Le on 11/10/16.
  */
-public class WsdlDownloader {
+public class SchemaDownloader {
     private BasicAuthentication basicAuthentication;
 
     public BasicAuthentication getBasicAuthentication() {
@@ -28,7 +28,7 @@ public class WsdlDownloader {
         this.basicAuthentication = basicAuthentication;
     }
 
-    public WsdlDownloader(BasicAuthentication basicAuthentication) {
+    public SchemaDownloader(BasicAuthentication basicAuthentication) {
         this.basicAuthentication = basicAuthentication;
     }
 
@@ -48,7 +48,7 @@ public class WsdlDownloader {
                 HttpURLConnection connection = initConnection(wsdlUrl, encoded);
 
                 writeStringToFile(
-                        createWsdlFile(downloadDirectory, basicAuthentication.getWsdlPrefixName(), index),
+                        createSchemaFile(downloadDirectory, basicAuthentication.getWsdlPrefixName(), index),
                         IOUtils.toString(connection.getInputStream(), Charset.defaultCharset()),
                         Charset.defaultCharset()
                 );
@@ -59,7 +59,7 @@ public class WsdlDownloader {
         }
     }
 
-    private File createWsdlFile(String downloadDirectory, String wsdlPrefixName, int index) {
+    private File createSchemaFile(String downloadDirectory, String wsdlPrefixName, int index) {
         wsdlPrefixName = StringUtils.isEmpty(wsdlPrefixName) ? "webservice_" : wsdlPrefixName + "_";
         return new File(downloadDirectory + File.separator + wsdlPrefixName + (index + 1) + ".wsdl");
     }

--- a/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/WsdlDownloader.java
+++ b/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/WsdlDownloader.java
@@ -1,0 +1,79 @@
+
+package org.jvnet.jaxb2.maven2;
+
+import static org.apache.commons.io.FileUtils.writeStringToFile;
+import static org.codehaus.plexus.util.Base64.encodeBase64;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.Charset;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+
+/**
+ * Created by Lucas Le on 11/10/16.
+ */
+public class WsdlDownloader {
+    private BasicAuthentication basicAuthentication;
+
+    public BasicAuthentication getBasicAuthentication() {
+        return basicAuthentication;
+    }
+
+    public void setBasicAuthentication(BasicAuthentication basicAuthentication) {
+        this.basicAuthentication = basicAuthentication;
+    }
+
+    public WsdlDownloader(BasicAuthentication basicAuthentication) {
+        this.basicAuthentication = basicAuthentication;
+    }
+
+    public void execute() throws MojoExecutionException {
+        for (int i = 0; i < basicAuthentication.getUrls().length; i++) {
+            String wsdlUrl = basicAuthentication.getUrls()[i];
+            System.out.println("Processing wsdlUrl: " + wsdlUrl);
+            download(wsdlUrl, basicAuthentication.getUsername(), basicAuthentication.getPassword(), basicAuthentication.getDownloadDirectory(), i);
+        }
+    }
+
+    private void download(String wsdlUrl, String username, String password, String downloadDirectory, int index) throws MojoExecutionException {
+        if (null != wsdlUrl) {
+            try {
+                String encoded = new String(encodeBase64((username + ":" + password).getBytes()));
+
+                HttpURLConnection connection = initConnection(wsdlUrl, encoded);
+
+                writeStringToFile(
+                        createWsdlFile(downloadDirectory, basicAuthentication.getWsdlPrefixName(), index),
+                        IOUtils.toString(connection.getInputStream(), Charset.defaultCharset()),
+                        Charset.defaultCharset()
+                );
+
+            } catch (IOException e) {
+                throw new MojoExecutionException("Download WSDL URL" + wsdlUrl, e);
+            }
+        }
+    }
+
+    private File createWsdlFile(String downloadDirectory, String wsdlPrefixName, int index) {
+        wsdlPrefixName = StringUtils.isEmpty(wsdlPrefixName) ? "webservice_" : wsdlPrefixName + "_";
+        return new File(downloadDirectory + File.separator + wsdlPrefixName + (index + 1) + ".wsdl");
+    }
+
+    private HttpURLConnection initConnection(String wsdlUrl, String encoded) throws IOException {
+        URL wsdl = new URL(wsdlUrl);
+
+        HttpURLConnection connection = (HttpURLConnection) wsdl.openConnection();
+
+        connection.setRequestMethod("GET");
+        connection.setDoOutput(true);
+        connection.setRequestProperty("Authorization", "Basic " + encoded);
+
+        return connection;
+    }
+
+}


### PR DESCRIPTION
I faced with a problem is my WSDLs is behind **web basic authentication** and there are more than 50 schema I need to generate so it is painful

These changes intent to download schema(s) to specific directory before executing the generation process, it set request header with **Authorization: Basic** and encodeBase64 username & password