### PR TITLE
Issue #31. Limit Up-to-date and target resource logging to debug mode

### DIFF
--- a/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/RawXJC2Mojo.java
+++ b/plugin-core/src/main/java/org/jvnet/jaxb2/maven2/RawXJC2Mojo.java
@@ -894,7 +894,7 @@ public abstract class RawXJC2Mojo<O> extends AbstractXJC2Mojo<O> {
 		final List<URI> dependsURIs = getDependsURIs();
 		final List<URI> producesURIs = getProducesURIs();
 
-		getLog().info(MessageFormat.format("Up-to-date check for source resources [{0}] and target resources [{1}].",
+		getLog().debug(MessageFormat.format("Up-to-date check for source resources [{0}] and target resources [{1}].",
 				dependsURIs, producesURIs));
 
 		boolean itIsKnownThatNoDependsURIsWereChanged = true;


### PR DESCRIPTION
To prevent console log from bloating in a project with large quantity of files: Up-to-date check for source resources and target resources logger has been changed to [debug level](https://maven.apache.org/general.html#How_to_produce_execution_debug_output_or_error_messages).